### PR TITLE
Update install script for new Generate-BinFile API

### DIFF
--- a/Sudo.1.0/tools/chocolateyInstall.ps1
+++ b/Sudo.1.0/tools/chocolateyInstall.ps1
@@ -1,5 +1,5 @@
 try{
-  Generate-BinFile 'Sudo' '%DIR%..\lib\Sudo.1.0\bin\sudo.cmd'
+  Generate-BinFile 'Sudo' '..\lib\Sudo.1.0\bin\sudo.cmd'
   Write-ChocolateySuccess 'sudo'
 } catch {
   Write-ChocolateyFailure 'sudo' "$($_.Exception.Message)"


### PR DESCRIPTION
Currently sudo doesn't install correctly.  The generated shim .exe can't successfully run sudo.cmd.  This small change to the `Generate-BinFile` arguments seems to fix the problem.  For whatever reason, current chocolately doesn't expand and doesn't need that `%DIR%` variable.

This pull request doesn't bump the version number cuz I'm not sure exactly how you want to do that.
