### PR TITLE
Retain current directory even with special chars

### DIFF
--- a/Sudo/bin/sudo.cmd
+++ b/Sudo/bin/sudo.cmd
@@ -4,7 +4,7 @@
 set SUDO_CMDLINE=%*
 set SUDO_ARG1=%1
 set SUDO_ARG2=%2
-set SUDO_CD=%CD%
+set SUDO_CD="%CD%"
 set SUDO_DRIVE=%CD:~0,2%
 
 :: %~dpn0 is refering to this files name and %* sends along the full commandline  


### PR DESCRIPTION
Current Version (via NuGet 1.1.1) doesn't support special characters in path like Space. In Windows paths with special characters must be escaped via double quotes.